### PR TITLE
Add support for offline registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,32 +2,36 @@
 [![BSD-3 Clause](https://ansible.l3d.space/svg/roles-ansible.forgeo_runner_license.svg)](LICENSE)
 [![Maintainance](https://ansible.l3d.space/svg/roles-ansible.forgeo_runner_maintainance.svg)](https://ansible.l3d.space/#roles-ansible.forgeo_runner)
 
- ansible role forgeo_runner
+ansible role forgeo_runner
 =======================
+
 Ansible role to install and Setup forgeo runner.
 
 Visit [code.forgejo.org/forgejo/runner](https://code.forgejo.org/forgejo/runner) for more information about forgejo actions.
 
- Requirements
+Requirements
 --------------
 
 This role requires either to be able to start docker containers as ``forgejo_runner`` User or you change the ``forgejo_runner__mode`` variable to run actions directly without containerisation which could break your system.
 
- Variables
+Variables
 -----------
-| Variable | Value | Description |
-| -------- | ----- | ----------- |
-| ``forgejo_runner__version`` | ``latest`` | Forgejo runner version or latest to use latest |
-| ``forgejo_runner__user`` | ``forgejo_runner`` | Forejo runner UNIX User |
-| ``forgejo_runner__group`` | ``forgejo_runner`` | Forgejo runner UNIX Group |
-| ``forgejo_runner__user_home`` | ``/var/lib/forgejo-runner`` | Unix Home and working directory |
-| ``forgejo_runner__full_executable_path`` | ``/usr/local/bin/forgejo_runner`` | Path for executable binary |
-| ``forgejo_runner__gpg_id`` | ``EB114F5E6C0DC2BCDD183550A4B61A2DC5923710`` | Forgejo runneer GPG Key |
-| ``forgejo_runner__instance_address`` | | Forgejo Instance Address |
-| ``forgejo_runner__token`` | | Token for runner of your forgejo instance |
-| ``forgejo_runner__mode`` | ``daemon`` | Forgejo runner mode. Change to ``exec`` for local Runner execution |
-| ``submodules_versioncheck`` | ``false`` | optional simple version check |
 
- Contribution
+| Variable                                 | Value                                        | Description                                                        |
+| ---------------------------------------- | -------------------------------------------- | ------------------------------------------------------------------ |
+| ``forgejo_runner__version``              | ``latest``                                   | Forgejo runner version or latest to use latest                     |
+| ``forgejo_runner__user``                 | ``forgejo_runner``                           | Forejo runner UNIX User                                            |
+| ``forgejo_runner__group``                | ``forgejo_runner``                           | Forgejo runner UNIX Group                                          |
+| ``forgejo_runner__user_home``            | ``/var/lib/forgejo-runner``                  | Unix Home and working directory                                    |
+| ``forgejo_runner__full_executable_path`` | ``/usr/local/bin/forgejo_runner``            | Path for executable binary                                         |
+| ``forgejo_runner__gpg_id``               | ``EB114F5E6C0DC2BCDD183550A4B61A2DC5923710`` | Forgejo runneer GPG Key                                            |
+| ``forgejo_runner__instance_address``     |                                              | Forgejo Instance Address                                           |
+| ``forgejo_runner__token``                |                                              | Token for runner of your forgejo instance                          |
+| ``forgejo_runner__offline_registration`` | ```false```                                  | Forgejo runner registration method                                 |
+| ``forgejo_runner__mode``                 | ``daemon``                                   | Forgejo runner mode. Change to ``exec`` for local Runner execution |
+| ``submodules_versioncheck``              | ``false``                                    | optional simple version check                                      |
+
+Contribution
 --------------
+
 Please feel free to open an issue or Pull-Request

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,6 +10,7 @@ forgejo_runner__gpg_id: 'EB114F5E6C0DC2BCDD183550A4B61A2DC5923710'
 forgejo_runner__instance_address: ''
 forgejo_runner__token: ''
 forgejo_runner__mode: "daemon"
+forgejo_runner__offline_registration: false
 
 # should we do a version check? (recomended)
 submodules_versioncheck: false

--- a/tasks/configure_runner.yml
+++ b/tasks/configure_runner.yml
@@ -37,4 +37,3 @@
     owner: "{{ forgejo_runner__user }}"
     group: "{{ forgejo_runner__group }}"
     mode: '0644'
-    

--- a/tasks/configure_runner.yml
+++ b/tasks/configure_runner.yml
@@ -20,7 +20,7 @@
     chdir: "{{ forgejo_runner__user_home }}"
     cmd: "{{ forgejo_runner__full_executable_path }} register --no-interactive --token '{{ forgejo_runner__token }}' --instance '{{ forgejo_runner__instance_address }}' --name '{{ inventory_hostname }}@ansible'"
     creates: "{{ forgejo_runner__user_home }}/.runner"
-  when: forgejo_runner__offline_registration == false
+  when: not forgejo_runner__offline_registration | bool
 
 - name: Register Forgejo runner via offline registration
   become: true
@@ -28,7 +28,7 @@
     chdir: "{{ forgejo_runner__user_home }}"
     cmd: "{{ forgejo_runner__full_executable_path }} create-runner-file --secret '{{ forgejo_runner__token }}' --instance '{{ forgejo_runner__instance_address }}' --name '{{ inventory_hostname }}@ansible'"
     creates: "{{ forgejo_runner__user_home }}/.runner"
-  when: forgejo_runner__offline_registration == true
+  when: forgejo_runner__offline_registration | bool
 
 - name: Change Owner of config
   become: true
@@ -37,3 +37,4 @@
     owner: "{{ forgejo_runner__user }}"
     group: "{{ forgejo_runner__group }}"
     mode: '0644'
+    

--- a/tasks/configure_runner.yml
+++ b/tasks/configure_runner.yml
@@ -20,6 +20,15 @@
     chdir: "{{ forgejo_runner__user_home }}"
     cmd: "{{ forgejo_runner__full_executable_path }} register --no-interactive --token '{{ forgejo_runner__token }}' --instance '{{ forgejo_runner__instance_address }}' --name '{{ inventory_hostname }}@ansible'"
     creates: "{{ forgejo_runner__user_home }}/.runner"
+  when: forgejo_runner__offline_registration == false
+
+- name: Register Forgejo runner via offline registration
+  become: true
+  ansible.builtin.command:
+    chdir: "{{ forgejo_runner__user_home }}"
+    cmd: "{{ forgejo_runner__full_executable_path }} create-runner-file --secret '{{ forgejo_runner__token }}' --instance '{{ forgejo_runner__instance_address }}' --name '{{ inventory_hostname }}@ansible'"
+    creates: "{{ forgejo_runner__user_home }}/.runner"
+  when: forgejo_runner__offline_registration == true
 
 - name: Change Owner of config
   become: true


### PR DESCRIPTION
I would love to see the support for [Offline registration](https://forgejo.org/docs/next/admin/actions/#registration) which is the suggested method for tools like ansible and terraform.

My simple solution is to add another boolean variable to control whether it's standard online registration or offline registration.